### PR TITLE
Streamline manual return functionality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcpptimer
 Type: Package
 Title: 'Rcpp' Tic-Toc Timer with 'OpenMP' Support
-Version: 1.1.1.9000
+Version: 1.2.0.9000
 Date: 2024-03-20
 Authors@R: c(
     person(given = "Jonathan",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+rcpptimer 1.2.0
+
+## Improvements
+
+* The `stop()` method of `Rcpp::Timer` now returns a DataFrame with the results. This is usefull if you want to set autoreturn to false and manually handle the results. It is also possible to just call `aggregate()` and access the public variable `data` of `Rcpp::Timer`. `data` is a map containing the results (Names, Mean, Standard Deviation, Count). 
+
 rcpptimer 1.1.0
 ==============
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 rcpptimer 1.2.0
+==============
 
 ## Improvements
 

--- a/inst/include/rcpptimer.h
+++ b/inst/include/rcpptimer.h
@@ -36,14 +36,15 @@ namespace Rcpp
       std::vector<unsigned long int> out_counts;
       std::vector<double> out_means, out_sd;
 
-      for (auto const &ent1 : data)
+      for (auto const &entry : data)
       {
         // Save tag
-        out_tags.push_back(ent1.first);
+        out_tags.push_back(entry.first);
 
-        unsigned long int count = std::get<2>(ent1.second);
-        double mean = std::get<0>(ent1.second);
-        double variance = std::get<1>(ent1.second) / count;
+        // Get count, mean and variance
+        unsigned long int count = std::get<2>(entry.second);
+        double mean = std::get<0>(entry.second);
+        double variance = std::get<1>(entry.second) / count;
 
         // Convert to milliseconds and round to 3 decimal places
         out_means.push_back(std::round(mean) * 1e-3);

--- a/inst/include/rcpptimer.h
+++ b/inst/include/rcpptimer.h
@@ -27,7 +27,7 @@ namespace Rcpp
     Timer(const char *name, bool verbose) : CppTimer(name, verbose) {}
 
     // Pass data to R / Python
-    void stop()
+    DataFrame stop()
     {
       aggregate();
 
@@ -51,14 +51,19 @@ namespace Rcpp
         out_counts.push_back(count);
       }
 
-      DataFrame df = DataFrame::create(
+      DataFrame results = DataFrame::create(
           Named("Name") = out_tags,
           Named("Milliseconds") = out_means,
           Named("SD") = out_sd,
           Named("Count") = out_counts);
 
-      Environment env = Environment::global_env();
-      env[name] = df;
+      if (autoreturn)
+      {
+        Environment env = Environment::global_env();
+        env[name] = results;
+      }
+
+      return results;
     }
 
     // Destructor

--- a/tests/testthat/test_autoreturn.R
+++ b/tests/testthat/test_autoreturn.R
@@ -1,0 +1,39 @@
+# Test if autoreturn works (default)
+Rcpp::cppFunction('
+void autoreturn_default()
+{
+  Rcpp::Timer timer;
+  Rcpp::Timer::ScopedTimer scoped_timer(timer, "t1");
+  timer.tic("t2");
+  std::string s;
+  s.reserve(1048576);
+  timer.toc("t2");
+}',
+  depends = "rcpptimer"
+)
+
+expect_no_warning(autoreturn_default())
+expect_no_error(autoreturn_default())
+expect_invisible(autoreturn_default())
+expect_contains(ls(as.environment(".GlobalEnv")), "times")
+
+rm(times, autoreturn_default)
+
+# Test that no output is returned when autoreturn is set to false
+Rcpp::cppFunction('
+void autoreturn_false()
+{
+  Rcpp::Timer timer;
+  timer.autoreturn = false;
+  Rcpp::Timer::ScopedTimer scoped_timer(timer, "t1");
+  timer.tic("t2");
+  std::string s;
+  s.reserve(1048576);
+  timer.toc("t2");
+}',
+  depends = "rcpptimer"
+)
+
+expect_no_warning(autoreturn_false())
+expect_no_error(autoreturn_false())
+expect_equal(ls(), "autoreturn_false")

--- a/tests/testthat/test_stop.R
+++ b/tests/testthat/test_stop.R
@@ -1,0 +1,54 @@
+# Test if the stop method return a dataframe with the results
+
+Rcpp::cppFunction('
+DataFrame manual_return()
+{
+  Rcpp::Timer timer;
+  {
+  Rcpp::Timer::ScopedTimer scoped_timer(timer, "t1");
+  timer.autoreturn = false;
+  timer.tic("t2");
+  std::string s;
+  s.reserve(1048576);
+  timer.toc("t2");
+  }
+  DataFrame results = timer.stop();
+  return(results);
+}',
+  depends = "rcpptimer"
+)
+
+expect_no_warning(manual_return())
+expect_no_error(manual_return())
+expect_visible(manual_return())
+results <- manual_return()
+expect_s3_class(results, "data.frame")
+
+# Test if the stop method and autoreturn work in conjunction
+
+Rcpp::cppFunction('
+DataFrame manual_return()
+{
+  Rcpp::Timer timer;
+  {
+  Rcpp::Timer::ScopedTimer scoped_timer(timer, "t1");
+  timer.autoreturn = true;
+  timer.tic("t2");
+  std::string s;
+  s.reserve(1048576);
+  timer.toc("t2");
+  }
+  DataFrame results = timer.stop();
+  return(results);
+}',
+  depends = "rcpptimer"
+)
+
+expect_no_warning(manual_return())
+expect_no_error(manual_return())
+expect_visible(manual_return())
+results <- manual_return()
+expect_s3_class(results, "data.frame")
+results_global <- as.environment(".GlobalEnv")$times
+expect_s3_class(results_global, "data.frame")
+expect_identical(results, results_global)

--- a/vignettes/autoreturn.Rmd
+++ b/vignettes/autoreturn.Rmd
@@ -1,0 +1,87 @@
+---
+title: "Automatic and Manual Return of the Timings"
+author: Jonathan Berrisch
+date: "`r Sys.Date()`"
+output:
+  rmarkdown::html_vignette:
+    number_sections: no
+    toc: no
+vignette: >
+  %\VignetteIndexEntry{Autoreturn}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+It may be necessary for you to handle the resulting DataFrame yourself instead of letting `rcpptimer` write it to the global environment. 
+
+The above actually consists of two elements:
+
+- Turn off the automatic return
+- Handle the results yourself
+
+First, to turn off the automatic return, set `autoreturn` to `false`. This will prevent the `timer` from writing the results to the global environment.
+
+```{r, eval = TRUE}
+Rcpp::cppFunction('
+int mem()
+{
+  Rcpp::Timer timer;
+  timer.autoreturn = false;
+  timer.tic("mem");
+  std::string s;
+  s.reserve(1048576);
+  timer.toc("mem");
+  return(0);
+}',
+  depends = "rcpptimer"
+)
+
+mem()
+
+print(ls())
+```
+
+Now, the results are not written to the global environment. Instead, you can access them through the `timer` object using the `stop()` method.
+
+```{r, eval = TRUE}
+Rcpp::cppFunction('
+DataFrame mem()
+{
+  Rcpp::Timer timer;
+  timer.autoreturn = false;
+  timer.tic("mem");
+  std::string s;
+  s.reserve(1048576);
+  timer.toc("mem");
+  DataFrame times = timer.stop();
+  return(times);
+}',
+  depends = "rcpptimer"
+)
+
+mem()
+```
+
+Its also possible to use `stop()` *and* let rcpptimer pass the results automatically. In the above example, we just set autoreturn to true (the default). 
+
+```{r, eval = TRUE}
+Rcpp::cppFunction('
+DataFrame mem()
+{
+  Rcpp::Timer timer;
+  timer.autoreturn = true;
+  timer.tic("mem");
+  std::string s;
+  s.reserve(1048576);
+  timer.toc("mem");
+  DataFrame times = timer.stop();
+  return(times);
+}',
+  depends = "rcpptimer"
+)
+
+manually_returned <- mem()
+print(ls())
+```
+
+In the above example, `mem()` returns the results *and* rcpptimer writes them as `times` to the global environment.

--- a/vignettes/rcpptimer.Rmd
+++ b/vignettes/rcpptimer.Rmd
@@ -73,6 +73,8 @@ mem()
 print(mytimes)
 ```
 
+It is also possible to deactivate this automatic passing of the results to R and handle the results in C++ yourself (see `vignette("autoreturn")`).
+
 ## Warnings and how to disable them
 
 The default setting will warn about timers that have not been stopped and `toc` calls for timers that have not yet been started using a matching call to `tic`:


### PR DESCRIPTION
This improves the user experience if autoreturn is set to false
Users should be able to call .stop() and get the results as a DataFrame.