### PR TITLE
Use nanoseconds resolution

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(
              role = c("aut", "cre"),
              email = "Jonathan@Berrisch.biz",
              comment = c(ORCID = "0000-0002-4944-9074")))
-Description: Provides 'Rcpp' bindings for 'cpptimer', a simple tic-toc timer class for benchmarking 'C++' code <https://github.com/BerriJ/cpptimer>. It's not just simple, it's blazing fast! This sleek tic-toc timer class supports overlapping timers as well as 'OpenMP' parallelism <https://www.openmp.org/>. It boasts a microsecond-level time resolution. We did not find any overhead of the timer itself at this resolution. Results (with summary statistics) are automatically passed back to 'R' as a data frame.
+Description: Provides 'Rcpp' bindings for 'cpptimer', a simple tic-toc timer class for benchmarking 'C++' code <https://github.com/BerriJ/cpptimer>. It's not just simple, it's blazing fast! This sleek tic-toc timer class supports overlapping timers as well as 'OpenMP' parallelism <https://www.openmp.org/>. It boasts a nanosecond-level time resolution. We did not find any overhead of the timer itself at this resolution. Results (with summary statistics) are automatically passed back to 'R' as a data frame.
 URL: https://rcpptimer.berrisch.biz
 License: GPL (>= 3)
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ rcpptimer 1.2.0
 * The `stop()` method of `Rcpp::Timer` now returns a DataFrame with the results. This is usefull if you want to set autoreturn to false and manually handle the results. It is also possible to just call `aggregate()` and access the public variable `data` of `Rcpp::Timer`. `data` is a map containing the results (Names, Mean, Standard Deviation, Count). 
 * The tag arguments of `tic()`, `toc()` and `ScopedTimer()` have default values now.
 * Existing vignettes got updated and a new vignette was added to the package.
+* rcpptimer now measures nanoseconds instead of microseconds.
 
 rcpptimer 1.1.0
 ==============

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rcpptimer - Rcpp Tic-Toc Timer with OpenMP Support
 
-This R Package provides Rcpp bindings for [cpptimer](https://github.com/BerriJ/cpptimer), a simple tic-toc timer class for benchmarking C++ code. It's not just simple, it's blazing fast! This sleek tic-toc timer class supports nested and overlapping timers and OpenMP parallelism. It boasts a microsecond-level time resolution. Results (with summary statistics) are automatically passed back to R as a data frame.
+This R Package provides Rcpp bindings for [cpptimer](https://github.com/BerriJ/cpptimer), a simple tic-toc timer class for benchmarking C++ code. It's not just simple, it's blazing fast! This sleek tic-toc timer class supports nested and overlapping timers and OpenMP parallelism. It boasts a nanosecond-level time resolution. Results (with summary statistics) are automatically passed back to R as a data frame.
 
 ## Install
 
@@ -49,7 +49,7 @@ Check out the [Documentation](https://rcpptimer.berrisch.biz/articles/rcpptimer.
 
 ## Limitations
 
-Processes taking less than a microsecond cannot be timed.
+Processes taking less than a nanosecond cannot be timed.
 
 Unmatched `.tic()` and `.toc()` calls do not raise errors at compile time. However, they throw warnings at runtime.
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ The timer object will automatically write its result to the R environment:
 
 ```r
 print(times)
-
- Name Milliseconds SD Count
-1 tictoc        0.005  0     1
+    Name Microseconds SD Count
+1 tictoc        7.418  0     1
 ```
 
 Check out the [Documentation](https://rcpptimer.berrisch.biz/articles/rcpptimer.html) for:

--- a/inst/include/rcpptimer.h
+++ b/inst/include/rcpptimer.h
@@ -47,7 +47,7 @@ namespace Rcpp
         double mean = std::get<0>(entry.second);
         double variance = std::get<1>(entry.second) / count;
 
-        // Convert to milliseconds and round to 3 decimal places
+        // Convert to microseconds and round to 3 decimal places
         out_means.push_back(std::round(mean) * 1e-3);
         out_sd.push_back(std::round(std::sqrt(variance * 1e-6) * 1e+3) * 1e-3);
         out_counts.push_back(count);
@@ -55,7 +55,7 @@ namespace Rcpp
 
       DataFrame results = DataFrame::create(
           Named("Name") = out_tags,
-          Named("Milliseconds") = out_means,
+          Named("Microseconds") = out_means,
           Named("SD") = out_sd,
           Named("Count") = out_counts);
 

--- a/inst/include/rcpptimer.h
+++ b/inst/include/rcpptimer.h
@@ -58,6 +58,7 @@ namespace Rcpp
           Named("Microseconds") = out_means,
           Named("SD") = out_sd,
           Named("Count") = out_counts);
+      results.attr("class") = CharacterVector({"rcpptimer", "data.frame"});
 
       if (autoreturn)
       {

--- a/inst/include/rcpptimer.h
+++ b/inst/include/rcpptimer.h
@@ -45,7 +45,7 @@ namespace Rcpp
         // Get count, mean and variance
         unsigned long int count = std::get<2>(entry.second);
         double mean = std::get<0>(entry.second);
-        double variance = std::get<1>(entry.second) / count;
+        double variance = std::get<1>(entry.second);
 
         // Convert to microseconds and round to 3 decimal places
         out_means.push_back(std::round(mean) * 1e-3);

--- a/tests/testthat/test_default.R
+++ b/tests/testthat/test_default.R
@@ -19,6 +19,6 @@ expect_contains(ls(as.environment(".GlobalEnv")), "times")
 
 expect_true(all(times$Name == c("scoped", "tictoc")))
 expect_true(all(!is.na(times)))
-expect_gte(min(times$Milliseconds), 0)
+expect_gte(min(times$Microseconds), 0)
 expect_gte(min(times$SD), 0)
 expect_gt(min(times$Count), 0)

--- a/tests/testthat/test_output.R
+++ b/tests/testthat/test_output.R
@@ -2,7 +2,7 @@ fibonacci(n = rep(5 * (1:8), 3))
 
 expect_contains(ls(as.environment(".GlobalEnv")), "times")
 expect_true(all(!is.na(times)))
-expect_gte(min(times$Milliseconds), 0)
+expect_gte(min(times$Microseconds), 0)
 expect_gte(min(times$SD), 0)
 expect_gt(min(times$Count), 0)
 
@@ -12,6 +12,6 @@ fibonacci_omp(n = rep(5 * (1:8), 3))
 
 expect_contains(ls(as.environment(".GlobalEnv")), "times")
 expect_true(all(!is.na(times)))
-expect_gte(min(times$Milliseconds), 0)
+expect_gte(min(times$Microseconds), 0)
 expect_gte(min(times$SD), 0)
 expect_gt(min(times$Count), 0)

--- a/tests/testthat/test_scopedtimer.R
+++ b/tests/testthat/test_scopedtimer.R
@@ -15,7 +15,7 @@ expect_invisible(scoped_timer())
 
 expect_contains(ls(as.environment(".GlobalEnv")), "times")
 expect_true(all(!is.na(times)))
-expect_gte(min(times$Milliseconds), 0)
+expect_gte(min(times$Microseconds), 0)
 expect_gte(min(times$SD), 0)
 expect_gt(min(times$Count), 0)
 expect_true(nrow(times) == 1)


### PR DESCRIPTION
I switched to microseconds in https://github.com/BerriJ/rcpptimer/commit/6d1403a3654285485bddd90f2161f03c131b8109 to be absolutely shure to not get integer overflows ever again.

However, as we moved from using a vector of ints to using a vector of unsigned long long ints for storing the durations, an overflow will only occur after 18446744073709551616 nanoseconds =  5124095 hours = 584 years. 

That is, we can safely move back to nanoseconds.