### PR TITLE
Make print.rcpptimer handle empty times object

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -63,7 +63,7 @@ test_reset <- function() {
     .Call(`_rcpptimer_test_reset`)
 }
 
-test_misc <- function(tic = TRUE, toc = TRUE, verbose = TRUE, autoreturn = TRUE) {
-    .Call(`_rcpptimer_test_misc`, tic, toc, verbose, autoreturn)
+test_misc <- function(tic = TRUE, toc = TRUE, verbose = TRUE, autoreturn = TRUE, scoped_timer = TRUE) {
+    .Call(`_rcpptimer_test_misc`, tic, toc, verbose, autoreturn, scoped_timer)
 }
 

--- a/R/print.rcpptimer.R
+++ b/R/print.rcpptimer.R
@@ -13,6 +13,11 @@
 #' @rdname print.rcpptimer
 #' @export
 print.rcpptimer <- function(x, scale = TRUE, ...) {
+  if (nrow(x) == 0) {
+    warning("This object does not contain any timings yet. \nPlace .tic() and .toc() statements in your c++ code to add timings.")
+    return(invisible(x))
+  }
+
   if (!scale) {
     print.data.frame(x, digits = 4, row.names = TRUE)
     return(invisible(x))

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -63,8 +63,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // test_misc
-DataFrame test_misc(const bool tic, const bool toc, const bool verbose, const bool autoreturn);
-RcppExport SEXP _rcpptimer_test_misc(SEXP ticSEXP, SEXP tocSEXP, SEXP verboseSEXP, SEXP autoreturnSEXP) {
+DataFrame test_misc(const bool tic, const bool toc, const bool verbose, const bool autoreturn, const bool scoped_timer);
+RcppExport SEXP _rcpptimer_test_misc(SEXP ticSEXP, SEXP tocSEXP, SEXP verboseSEXP, SEXP autoreturnSEXP, SEXP scoped_timerSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -72,7 +72,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const bool >::type toc(tocSEXP);
     Rcpp::traits::input_parameter< const bool >::type verbose(verboseSEXP);
     Rcpp::traits::input_parameter< const bool >::type autoreturn(autoreturnSEXP);
-    rcpp_result_gen = Rcpp::wrap(test_misc(tic, toc, verbose, autoreturn));
+    Rcpp::traits::input_parameter< const bool >::type scoped_timer(scoped_timerSEXP);
+    rcpp_result_gen = Rcpp::wrap(test_misc(tic, toc, verbose, autoreturn, scoped_timer));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -83,7 +84,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rcpptimer_test_default", (DL_FUNC) &_rcpptimer_test_default, 0},
     {"_rcpptimer_test_update", (DL_FUNC) &_rcpptimer_test_update, 0},
     {"_rcpptimer_test_reset", (DL_FUNC) &_rcpptimer_test_reset, 0},
-    {"_rcpptimer_test_misc", (DL_FUNC) &_rcpptimer_test_misc, 4},
+    {"_rcpptimer_test_misc", (DL_FUNC) &_rcpptimer_test_misc, 5},
     {NULL, NULL, 0}
 };
 

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -61,10 +61,12 @@ List test_reset()
 DataFrame test_misc(const bool tic = true,
                     const bool toc = true,
                     const bool verbose = true,
-                    const bool autoreturn = true)
+                    const bool autoreturn = true,
+                    const bool scoped_timer = true)
 {
   Rcpp::Timer timer(verbose);
   timer.autoreturn = autoreturn;
+  if (scoped_timer)
   {
     Rcpp::Timer::ScopedTimer scoped_timer(timer, "t1");
     if (tic)

--- a/tests/testthat/test_print.rcpptimer.R
+++ b/tests/testthat/test_print.rcpptimer.R
@@ -86,3 +86,10 @@ times$Microseconds <- c(5e+3, 5e+3, 5e+3)
 expect_output(p_out <- print(times, FALSE))
 testthat::expect_contains(colnames(p_out), "Microseconds")
 expect_equal(p_out$Microseconds, c(5e+3, 5e+3, 5e+3))
+
+expect_no_condition(out <- test_misc(tic = FALSE, toc = FALSE, scoped_timer = FALSE))
+
+expect_warning(
+  print(out),
+  "This object does not contain any timings yet."
+)


### PR DESCRIPTION
`print.rcpptimer` failed when the times object is empty.

This PR fixes this and gives a warning about this to the user when trying to print an empty times object.